### PR TITLE
feat: ignore 'local'/'global' pseudo classes

### DIFF
--- a/stylelintrc.json
+++ b/stylelintrc.json
@@ -1,3 +1,14 @@
 {
-  "extends": "stylelint-config-standard"
+  "extends": "stylelint-config-standard",
+  "rules": {
+    "selector-pseudo-class-no-unknown": [
+      true,
+      {
+        "ignorePseudoClasses": [
+          "local",
+          "global"
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
Allow usage of webpack/css-loader :local() and :global() selector helpers