### PR TITLE
feat: update stylelint-config-standard

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,7 @@
 {
-  "extends": "mailonline"
+  "extends": "mailonline",
+  "rules": {
+    "import/no-commonjs": "off",
+    "import/unambiguous": "off"
+  }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 *.log
+yarn.lock

--- a/index.js
+++ b/index.js
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-commonjs
 module.exports = require('./stylelintrc.json');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "stylelint-config-standard": "^14.0.0"
+    "stylelint-config-standard": "^16.0.0"
   },
   "description": "MailOnline stylelint configuration.",
   "devDependencies": {


### PR DESCRIPTION
BREAKING CHANGE: Updating from version 14.0.0 to 16.0.0 please go to
https://github.com/stylelint/stylelint-config-standard/blob/master/CHANGELOG.md
to see the breaking changes

The new version removes all the deprecated rules and adds [`font-family-no-duplicate-names`](https://stylelint.io/user-guide/rules/font-family-no-duplicate-names/) rule