### PR TITLE
fix: add ignores to at-rule-no-unknown

### DIFF
--- a/stylelintrc.json
+++ b/stylelintrc.json
@@ -1,6 +1,21 @@
 {
   "extends": "stylelint-config-standard",
   "rules": {
+    "at-rule-no-unknown": [
+      true,
+      {
+        "ignoreAtRules": [
+          "include",
+          "extend",
+          "if",
+          "content",
+          "each",
+          "return",
+          "mixin",
+          "function"
+        ]
+      }
+    ],
     "property-no-unknown": [
       true,
       {


### PR DESCRIPTION
It's a fix since currently linting breaks on code we consider valid (after the breaking changes in stylelint standard config)