### PR TITLE
MOL-29290: ammend wrong rules

### DIFF
--- a/stylelintrc.js
+++ b/stylelintrc.js
@@ -13,6 +13,7 @@ module.exports = {
     }
   ],
   "rules": {
+    "alpha-value-notation": "number", // using "number" here because "percentile" is not supported in rgba function and may break the code if used
     "keyframes-name-pattern": null,
     "no-invalid-position-at-import-rule": null,
     "property-no-unknown": [


### PR DESCRIPTION
https://jira.mol.dmgt.net/browse/MOL-29290

The "alpha-value-notation" rule was being used as "percentile", which was causing the CSS to get broken in every rgba function, because the transparency parameter in rgba functions does not allow percentages; it needs to be a number between 0 and 1. 

Check this for reference: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/rgb

Example of the error:
![image (1)](https://github.com/MailOnline/stylelint-config-mailonline/assets/39515333/6e77217b-9e94-4dd7-822b-ed92c43290c0)

To fix this error, I set the "alpha-value-notation" rule to "number" so that projects have consistency but do not break the final CSS files.

Issues: MOL-29290